### PR TITLE
fix: pass serve options to serve:http command

### DIFF
--- a/src/Commands/ServeCommand.php
+++ b/src/Commands/ServeCommand.php
@@ -22,7 +22,7 @@ class ServeCommand extends Command
         $artisanPath = base_path('artisan');
 
         $processes = [
-            $httpProcess = new Process([$phpBinaryPath, $artisanPath, 'serve:http'] + $this->serveOptions()),
+            $httpProcess = new Process(array_merge([$phpBinaryPath, $artisanPath, 'serve:http'], $this->serveOptions())),
             $socketProcess = new Process([$phpBinaryPath, $artisanPath, 'serve:websockets']),
         ];
 


### PR DESCRIPTION
initially if you pass --host or --port were not passed to the end command serve:http, by merging the array the bug is fixed